### PR TITLE
Add require.resolve() just to be safe

### DIFF
--- a/machines/require.js
+++ b/machines/require.js
@@ -82,7 +82,7 @@ module.exports = {
     // If `inputs.clearCache` is set, clear this path from the require
     // cache before attempting to load.
     if (inputs.clearCache) {
-      delete require.cache[absPath];
+      delete require.cache[require.resolve(absPath)];
     }
 
     // Attempt to require the module.


### PR DESCRIPTION
@sgress454 I was actually about to do a PR adding this, because I found myself needing it, and was pleasantly surprised to see it was already here 👍 

This PR adds `require.resolve()` just to be safe (see http://stackoverflow.com/questions/9210542/node-js-require-cache-possible-to-invalidate).  I doubt it would matter, but just in case Node gets fresh.