### PR TITLE
Pin and update deps plus hash

### DIFF
--- a/machines/hash.js
+++ b/machines/hash.js
@@ -40,6 +40,8 @@ module.exports = {
 
   fn: function(inputs, exits) {
 
+    throw new Error('Doing this in the next commit');
+
     // Import `object-hash` as `hashFn`.
     var hashFn = require('object-hash');
 

--- a/machines/inspect.js
+++ b/machines/inspect.js
@@ -40,8 +40,8 @@ module.exports = {
     var util = require('util');
 
     // Import the `isError` and `isObject` Lodash functions.
-    var isError = require('lodash.iserror');
-    var isObject = require('lodash.isobject');
+    var isError = require('lodash').isError;
+    var isObject = require('lodash').isObject;
 
     // If the value is an error, output its stack through the `success` exit.
     if (isError(inputs.value)) {

--- a/package.json
+++ b/package.json
@@ -18,14 +18,11 @@
     ]
   },
   "dependencies": {
-    "async": "^2.0.1",
+    "async": "2.0.1",
     "browserify-transform-machinepack": "^1.0.3",
     "lodash": "3.10.1",
-    "lodash.iserror": "3.1.1",
-    "lodash.isobject": "3.0.2",
-    "machine": "^12.3.0",
-    "object-hash": "0.5.0",
-    "resolve": "^1.1.7"
+    "machine": "^13.0.0-7",
+    "resolve": "1.1.7"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "url": "git@github.com:treelinehq/machinepack-util.git"
   },
   "devDependencies": {
-    "mocha": "2.1.0",
-    "test-machinepack-mocha": "^2.1.1"
+    "mocha": "3.0.2",
+    "test-machinepack-mocha": "^2.1.6"
   },
   "machinepack": {
     "friendlyName": "Util",


### PR DESCRIPTION
- Cleans up unecessary deps (removes lodash.isobject and lodash.iserror in favor of just lodash)
- Upgrades to simpler, more manual hash function that we're using in the machine runner (and removes object-hash as a dependency).  This means that client vs. server hashes should be 100% identical now.
- Upgrades dev deps to mocha 3 to get rid of deprecation message.
- Pins semver ranges of all deps that we don't maintain ourselves
- Bumps, pops, and locks async version to the standard (v2.0.1) to optimize browserify build
